### PR TITLE
fix: parameter name of update_mimetype command

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1467,7 +1467,7 @@ function M:preload()
 	end
   
 	if #mimes then
-	  ya.manager_emit("update_mimetype", {}, mimes)
+	  ya.manager_emit("update_mimetype", { updates = mimes })
 	  return 3
 	end
 	return 2


### PR DESCRIPTION
The third parameter of `manager_emit()` will be deprecated in Yazi 0.2.5.

The `update_mimetype` command is the only place where it is used, this PR fixes it.